### PR TITLE
Adopt code for Python 3 interpreter

### DIFF
--- a/decode-pcap.py
+++ b/decode-pcap.py
@@ -2,6 +2,8 @@
 # Turns a pcap file with http gzip compressed data into plain text, making it
 # easier to follow.
 
+from __future__ import print_function
+
 import dpkt
 import gzip
 import sys
@@ -33,7 +35,7 @@ def pcap_stream(filenames, ports):
         else:
             assert False, "Don't know how to parse file: "+filename
 
-        print >> sys.stderr, file_num, filename
+        print(file_num, filename, file=sys.stderr)
         
         with f:
             pcap = dpkt.pcap.Reader(f)
@@ -51,14 +53,14 @@ def pcap_stream(filenames, ports):
 
                 result = None
 
-        print >> sys.stderr, "total packets(%s): %s, ignored %s" % (filename, packet_num, ignored)
+        print("total packets(%s): %s, ignored %s" % (filename, packet_num, ignored), file=sys.stderr)
 
         file_num += 1
 
 
 def parse_pcap_files(filenames, ng = False):
 
-    print >> printing.http_stream, printing.header()
+    print(printing.header(), file=printing.http_stream)
 
     for lite_tcp_session in pcap_lite_sessions(pcap_stream(filenames,ports)):
         
@@ -70,7 +72,7 @@ def parse_pcap_files(filenames, ng = False):
 
 def parse_splitted_files(filenames, ng = False):
 
-    print >> printing.http_stream, printing.header()
+    print(printing.header(), file=printing.http_stream)
     for filename in sorted(filenames):
         for lite_tcp_session in pcap_lite_sessions(pcap_stream([filename],ports)):
             if ng:
@@ -98,7 +100,7 @@ def split_pcap_files(filenames):
 
             f=gzip.open(outdir+"/pcap%03d.pcap.gz" % fnum, 'wb')
             pcap = dpkt.pcap.Writer(f)
-            print >> sys.stderr, outdir+"/pcap%03d.pcap.gz" % fnum
+            print(outdir+"/pcap%03d.pcap.gz" % fnum, file=sys.stderr)
 
         for ts,buf in lite_tcp_session.raw_packets():
             pcap.writepkt(buf,ts)
@@ -113,7 +115,7 @@ def split_pcap_files(filenames):
 if __name__ == '__main__':
     import sys
     if len(sys.argv) <= 3:
-        print "%s outdir (parse|sparse|split) <pcap filename(s)>" % sys.argv[0]
+        print("%s outdir (parse|sparse|split) <pcap filename(s)>" % sys.argv[0])
         sys.exit(2)
 
     new_generation = 'ng' in sys.argv[0]
@@ -151,7 +153,7 @@ if __name__ == '__main__':
         split_pcap_files(sorted(sys.argv[3:]))
 
     else:
-        print "%s outdir (parse|sparse|split) <pcap filename(s)>" % sys.argv[0]
+        print("%s outdir (parse|sparse|split) <pcap filename(s)>" % sys.argv[0])
 
 
 

--- a/httprecord.py
+++ b/httprecord.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import dpkt
 import sys
 import zlib
@@ -180,7 +182,7 @@ class HTTPRequest(dpkt.http.Request):
         if 'user-agent' in self.headers:
             self.user_agent=self.headers['user-agent']
             if isinstance(self.user_agent,list):
-                print >> sys.stderr, "several user agent headers: %s" % self.user_agent
+                print("several user agent headers: %s" % self.user_agent, file=sys.stderr)
                 self.user_agent=self.user_agent[0]
             self.user_agent=self.user_agent.replace('\t',' ')
 

--- a/parsing.py
+++ b/parsing.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from tcpsession import TCPSession, tcp_flags, SeqException
 from httpsession import parse_http_streams, HTTPParsingError, HTTPResponse, HTTPRequest
 from refactoring.errors import *
@@ -64,12 +66,12 @@ def parse_session_pair(connection,reverse_connection):
         http_items += [err]
         if error_packet is None or error_packet>err.packet_num:
             error_packet=err.packet_num
-        #print >> http_reqs, "connection:", err, "packet:", err.packet_num
-        print >> printing.debug_stream, "connection:", err, "packet:", err.packet_num
+        #print("connection:", err, "packet:", err.packet_num, file=http_reqs)
+        print("connection:", err, "packet:", err.packet_num, file=printing.debug_stream)
 
     try:
         rstream = reverse_connection.stream()
-        #print stream        
+        #print(stream)
         if rstream:
             for http_item in parse_http_streams(reverse_connection.directed_key, rstream, reverse_connection.pair.content, reverse_connection.content):
                 http_items += [http_item]
@@ -77,8 +79,8 @@ def parse_session_pair(connection,reverse_connection):
         http_items += [err]
         if error_packet is None or error_packet>err.packet_num:
             error_packet=err.packet_num
-        #print >> http_reqs, "reverse:", err, "packet:", err.packet_num
-        print >> printing.debug_stream, "reverse:", err, "packet:", err.packet_num
+        #print("reverse:", err, "packet:", err.packet_num, file=http_reqs)
+        print("reverse:", err, "packet:", err.packet_num, file=printing.debug_stream)
 
 
     for x in http_items: 
@@ -147,5 +149,5 @@ def handle_lite_tcp_session(lite_tcp_session):
 
     except (SeqException) as e:
     #except (SeqException,SSLSkipError) as e:
-        print >> sys.stderr, e
+        print(e, file=sys.stderr)
 

--- a/refactoring/parsing_ng.py
+++ b/refactoring/parsing_ng.py
@@ -1,8 +1,10 @@
-from tcprecord import TCPRecord, TCPRecordStream
+from __future__ import print_function
+
+from refactoring.tcprecord import TCPRecord, TCPRecordStream
 from httprecord import HTTPRecordStream
 from tcpsession import TCPSession, tcp_flags, SeqException
 from httpsession import parse_http_streams, HTTPParsingError, HTTPResponse, HTTPRequest
-from errors import *
+from refactoring.errors import *
 import sys
 
 import printing
@@ -64,16 +66,16 @@ def handle_lite_tcp_session_ng(lite_tcp_session):
 
                 tcp_record_stream = TCPRecordStream(connection.content, reverse_connection.content)
                 http_record_stream = HTTPRecordStream(tcp_record_stream)
-                print str(tcp_record_stream)
-                print str(http_record_stream)
+                print(str(tcp_record_stream))
+                print(str(http_record_stream))
 
             except(StreamClassError) as err:
-                print >> sys.stderr, err
+                print(err, file=sys.stderr)
 
 
     except(ConnectionClassError) as err:
-        print >> sys.stderr, err
+        print(err, file=sys.stderr)
 
     except(FatalClassError) as err:
-        print >> sys.stderr, err
+        print(err, file=sys.stderr)
         raise

--- a/refactoring/tcprecord.py
+++ b/refactoring/tcprecord.py
@@ -1,8 +1,10 @@
+#from __future__ import print_function
+
 import sys
 
-from baserecord import BaseRecord, BaseRecordStream
+from refactoring.baserecord import BaseRecord, BaseRecordStream
 from tcpsession import TCPSession
-from errors import RecordClassError,StreamClassError,ConnectionClassError,FatalClassError
+from refactoring.errors import RecordClassError,StreamClassError,ConnectionClassError,FatalClassError
 
 class TCPRecord(BaseRecord):
 
@@ -34,7 +36,7 @@ class TCPRecord(BaseRecord):
 
         for packet in self.packets:
             results += packet.data
-            #print >> sys.stderr, packet.adjusted_seq, len(packet.data)
+            #print(packet.adjusted_seq, len(packet.data), file=sys.stderr)
 
         #foo = ' '.join([str(len(p.data)) for p in self.packets])
 


### PR DESCRIPTION
Adopt the code to support interpretation with Python 3.

1. Use `from __future__ import print_function`.
1. Change `print ...` to `print(..., file=..., end=...)`.
1. Remove unused or obsolete imports, add missing ones, fix wrong twos.
1. Use `b'...'` format for binary string literals.
1. Use `//` for integer divisions.
1. Use `for key in dictionary: ...` format to iterate over dictionaries.
1. Use `for key, value in dictionary.items(): ...` format to iterate over dictionaries with key-value pairs being used.
1. Add a Python 2 & 3 compatible filtering of non-printable characters.
1. Fix a typo in `/litesession.py`: `prevseq` --> `prev_seq`.
1. Fix a type testing in `/printing.py`: `t is float` --> `type(t) is float`.
1. Remove `fixed_parse_opts` function, use original `dptk.tcp.parse_opts` instead. The one has been fixed in https://github.com/kbandla/dpkt/issues/139.